### PR TITLE
Feature/parallel limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ to start the schedule worker. Worker will automatically load all events from the
 | intervalLimit |                       Worker stops automatically after give amount of intervals.                       |      int      |    -    |
 | memoryLimit   |                 Worker stops automatically if usage of memory exceeds the given limit.                 |  int (bytes)  |    -    |
 | parallel      |                             Worker runs events in parallel if set to true.                             |    boolean    |  false  |
+| parallelLimit |                   Let worker run only defined amount of parallel runs at same time.                    |      int      |    -    |
 
 
 ### Setup Schedule Worker (own script)

--- a/src/Command/RunWorkerCommand.php
+++ b/src/Command/RunWorkerCommand.php
@@ -76,6 +76,13 @@ final class RunWorkerCommand extends Console\Command\Command
             'Allow worker to run events parallel.',
             null,
         );
+        $this->addOption(
+            WorkerOptions::PARALLEL_EXECUTION_LIMIT,
+            null,
+            Console\Input\InputOption::VALUE_REQUIRED,
+            'The maximum number of parallel events to run.',
+            0,
+        );
         $this->addArgument(
             'schedule-event',
             Console\Input\InputArgument::IS_ARRAY,
@@ -97,6 +104,7 @@ final class RunWorkerCommand extends Console\Command\Command
                 WorkerOptions::TIME_LIMIT => $input->getOption(WorkerOptions::TIME_LIMIT),
                 WorkerOptions::MEMORY_LIMIT => $input->getOption(WorkerOptions::MEMORY_LIMIT),
                 WorkerOptions::PARALLEL_EXECUTION => $input->getOption(WorkerOptions::PARALLEL_EXECUTION),
+                WorkerOptions::PARALLEL_EXECUTION_LIMIT => $input->getOption(WorkerOptions::PARALLEL_EXECUTION_LIMIT),
             ],
             $io,
         );

--- a/src/Constants/WorkerOptions.php
+++ b/src/Constants/WorkerOptions.php
@@ -24,11 +24,14 @@ final class WorkerOptions
 
     public const PARALLEL_EXECUTION = 'parallel';
 
+    public const PARALLEL_EXECUTION_LIMIT = 'parallelLimit';
+
     public const DEFAULTS = [
         self::SCHEDULE_EVENT_LIMIT => null,
         self::TIME_LIMIT => null,
         self::MEMORY_LIMIT => null,
         self::INTERVAL_LIMIT => null,
         self::PARALLEL_EXECUTION => false,
+        self::PARALLEL_EXECUTION_LIMIT => null,
     ];
 }

--- a/src/Event/Event/Execute/WorkerExecuteParallelInitEvent.php
+++ b/src/Event/Event/Execute/WorkerExecuteParallelInitEvent.php
@@ -14,7 +14,7 @@ namespace Flexic\Scheduler\Event\Event\Execute;
 
 use Flexic\Scheduler\Interfaces\ScheduleEventInterface;
 
-final class WorkerExecuteParallelStartEvent
+final class WorkerExecuteParallelInitEvent
 {
     public function __construct(
         readonly private ScheduleEventInterface $scheduleEvent,

--- a/src/Event/Event/Execute/WorkerExecuteParallelResumeEvent.php
+++ b/src/Event/Event/Execute/WorkerExecuteParallelResumeEvent.php
@@ -12,9 +12,17 @@ declare(strict_types=1);
 
 namespace Flexic\Scheduler\Event\Event\Execute;
 
+use Flexic\Scheduler\Configuration\WorkerConfiguration;
+
 final class WorkerExecuteParallelResumeEvent
 {
-    public function __construct()
+    public function __construct(
+        readonly private WorkerConfiguration $workerConfiguration,
+    ) {
+    }
+
+    public function getWorkerConfiguration(): WorkerConfiguration
     {
+        return $this->workerConfiguration;
     }
 }

--- a/src/Event/Listener/WorkerExecutionListener.php
+++ b/src/Event/Listener/WorkerExecutionListener.php
@@ -34,7 +34,7 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
         return [
             Event\Execute\WorkerExecuteEvent::class => 'onWorkerExecute',
             Event\Execute\WorkerExecuteSequentialEvent::class => 'onWorkerExecuteSequential',
-            Event\Execute\WorkerExecuteParallelStartEvent::class => 'onStartParallelExecution',
+            Event\Execute\WorkerExecuteParallelInitEvent::class => 'onInitParallelExecution',
             Event\Execute\WorkerExecuteParallelResumeEvent::class => 'onResumeParallelExecution',
         ];
     }
@@ -53,7 +53,7 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
         ));
 
         if ($event->getWorkerConfiguration()->getOption(WorkerOptions::PARALLEL_EXECUTION)) {
-            $eventDispatcher->dispatch(new Event\Execute\WorkerExecuteParallelStartEvent($scheduleEvent));
+            $eventDispatcher->dispatch(new Event\Execute\WorkerExecuteParallelInitEvent($scheduleEvent));
         } else {
             $eventDispatcher->dispatch(new Event\Execute\WorkerExecuteSequentialEvent($scheduleEvent));
         }
@@ -73,31 +73,44 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
         $scheduleEvent();
     }
 
-    public function onStartParallelExecution(Event\Execute\WorkerExecuteParallelStartEvent $event): void
+    public function onInitParallelExecution(Event\Execute\WorkerExecuteParallelInitEvent $event): void
     {
         $scheduleEvent = $event->getScheduleEvent();
 
-        $fiber = new \Fiber(static function () use ($scheduleEvent): void {
+        $this->parallelExecution[] = new \Fiber(static function () use ($scheduleEvent): void {
             \Fiber::suspend();
 
             $scheduleEvent();
         });
 
-        $fiber->start();
 
-        $this->parallelExecution[] = $fiber;
     }
 
-    public function onResumeParallelExecution(): void
+    public function onResumeParallelExecution(Event\Execute\WorkerExecuteParallelResumeEvent $event): void
     {
-        foreach ($this->parallelExecution as $fiber) {
-            if (!$fiber->isStarted()) {
-                throw new \RuntimeException('Parallel execution is not started.');
-            }
+        $maxParallelExecution = $event->getWorkerConfiguration()->getOption(WorkerOptions::PARALLEL_EXECUTION_LIMIT);
 
-            $fiber->resume();
+        if ($maxParallelExecution <= 0) {
+            $maxParallelExecution = \count($this->parallelExecution);
         }
 
-        $this->parallelExecution = [];
+        while (\count($this->parallelExecution) > 0) {
+            $started = [];
+            foreach ($this->parallelExecution as $key => $fiber) {
+                if (\count($started) >= $maxParallelExecution) {
+                    break;
+                }
+
+                if (!$fiber->isStarted()) {
+                    $fiber->start();
+                    $started[$key] = $fiber;
+                }
+            }
+
+            foreach ($started as $key => $fiber) {
+                $fiber->resume();
+                unset($this->parallelExecution[$key]);
+            }
+        }
     }
 }

--- a/src/Event/Listener/WorkerExecutionListener.php
+++ b/src/Event/Listener/WorkerExecutionListener.php
@@ -82,20 +82,19 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
 
             $scheduleEvent();
         });
-
-
     }
 
     public function onResumeParallelExecution(Event\Execute\WorkerExecuteParallelResumeEvent $event): void
     {
         $maxParallelExecution = $event->getWorkerConfiguration()->getOption(WorkerOptions::PARALLEL_EXECUTION_LIMIT);
 
-        if ($maxParallelExecution <= 0) {
+        if (0 >= $maxParallelExecution) {
             $maxParallelExecution = \count($this->parallelExecution);
         }
 
         while (\count($this->parallelExecution) > 0) {
             $started = [];
+
             foreach ($this->parallelExecution as $key => $fiber) {
                 if (\count($started) >= $maxParallelExecution) {
                     break;

--- a/src/Event/Listener/WorkerExecutionListener.php
+++ b/src/Event/Listener/WorkerExecutionListener.php
@@ -109,7 +109,7 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
             $event->getWorkerConfiguration()->getLogger()->info(\sprintf(
                 'Started %s parallel executions of remaining %s.',
                 \count($started),
-                \count($this->parallelExecution)
+                \count($this->parallelExecution),
             ));
 
             foreach ($started as $key => $fiber) {

--- a/src/Event/Listener/WorkerExecutionListener.php
+++ b/src/Event/Listener/WorkerExecutionListener.php
@@ -97,7 +97,7 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
 
             foreach ($this->parallelExecution as $key => $fiber) {
                 if (\count($started) >= $maxParallelExecution) {
-                    break;
+                    continue;
                 }
 
                 if (!$fiber->isStarted()) {
@@ -105,6 +105,12 @@ final class WorkerExecutionListener implements EventSubscriberInterface, LoggerA
                     $started[$key] = $fiber;
                 }
             }
+
+            $event->getWorkerConfiguration()->getLogger()->info(\sprintf(
+                'Started %s parallel executions of remaining %s.',
+                \count($started),
+                \count($this->parallelExecution)
+            ));
 
             foreach ($started as $key => $fiber) {
                 $fiber->resume();

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -131,7 +131,7 @@ final class Worker extends BaseWorker
                 $this->timezone->default();
             }
 
-            $this->eventDispatcher->dispatch(new Event\Execute\WorkerExecuteParallelResumeEvent());
+            $this->eventDispatcher->dispatch(new Event\Execute\WorkerExecuteParallelResumeEvent($this->configuration));
 
             $this->eventDispatcher->dispatch(new Event\Interval\WorkerIntervalEndEvent($this->configuration, $interval));
 


### PR DESCRIPTION
This PR adds feature to limit events in parallel. 
Whenever `--parallel` mode is activated the system create and runs by default an fiber.
When e.g. `--parallelLimit=2` is set system run only 2 events at the same time and wait until spawn next ones.

This should bring possibility to manage the usage of cpu and memory when using parallel mode.