### PR TITLE
Ensure `Timer::getTimeUntilNextTick()` returns a minimum of 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .build
 .dev
 vendor
+
+.idea
+.vscode

--- a/src/Time/Timer.php
+++ b/src/Time/Timer.php
@@ -30,6 +30,6 @@ final class Timer
             0,
         );
 
-        return $next->getTimestamp() - $actual->getTimestamp();
+        return \max(0, $next->getTimestamp() - $actual->getTimestamp());
     }
 }


### PR DESCRIPTION
Resolves this error I get sporadically

```
PHP Fatal error:  Uncaught ValueError: sleep(): Argument #1 ($seconds) must be
greater than or equal to 0 in /app/vendor/flexic/scheduler/src/Time/Timer.php:21
```